### PR TITLE
Update README to checkout amplify env before push

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ Outputs:
 }
 ```
 
-- Now save the changes & do `amplify push` again to have queue on cloud. 
+- Now save the changes
+- Let the CLI know about our custom category and resource by checking out the current environment. `amplify env checkout <env-name>`
+- Do `amplify push` again to have queue on cloud. 
 - We can see our queue on console
  <img src="https://user-images.githubusercontent.com/74547936/146829784-953d4425-5bda-4c65-a96f-b78a49dfa937.png" width="900">
 - If everything is pushed on cloud with not issues, you can move to the next part.


### PR DESCRIPTION
Thanks for your tutorial, it's fantastic. I found that the queue wasn't showing up with an `amplify push`; I found in a similar tutorial [here](https://cevo.com.au/post/post-2020-10-14-extend-aws-amplify-with-custom-resources/) that I needed to do an `amplify env checkout <env-name>` to let the amplify CLI pick up the new category; once I'd done this it worked for me.